### PR TITLE
Add tegoeden

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,3 +11,229 @@
         );
     }
     add_action( 'wp_enqueue_scripts', 'my_theme_enqueue_styles' );
+
+
+    /* 
+     *  BuddyPress add additional tabs Studie bedrag & Studie dagen
+     */
+
+    function ibenic_buddypress_tab() {
+        global $bp;
+        bp_core_new_nav_item( array( 
+            'name' => __( 'Studie bedrag', 'ibenic' ), 
+            'slug' => 'studie-bedrag', 
+            'position' => 100,
+            'screen_function' => 'ibenic_budypress_studie_bedrag',
+            'show_for_displayed_user' => true,
+            'item_css_id' => 'fa-money',
+        ) );
+        bp_core_new_nav_item( array( 
+            'name' => __( 'Studie dagen', 'ibenic' ),
+            'slug' => 'studie-dagen', 
+            'position' => 100,
+            'screen_function' => 'ibenic_budypress_studie_dagen',
+            'show_for_displayed_user' => true,
+            'item_css_id' => 'fa-calendar',
+        ) );
+    }
+    add_action( 'bp_setup_nav', 'ibenic_buddypress_tab', 1000 );
+
+    // Populate the bedrag tab
+    function ibenic_budypress_studie_bedrag () {
+        add_action( 'bp_template_title', function () { _e( 'Tegoed aantal studie dagen', 'ibenic' ); } );
+        add_action( 'bp_template_content', function () { display_tegoed('bedrag'); } );
+        bp_core_load_template( apply_filters( 'bp_core_template_plugin', 'members/single/plugins' ) );
+    }
+
+    // Populate the dagen tab
+    function ibenic_budypress_studie_dagen () {
+        add_action( 'bp_template_title', function () { _e( 'Bedrag aan studie tegoed', 'ibenic' ); } );
+        add_action( 'bp_template_content', function () { display_tegoed('dagen'); } );
+        bp_core_load_template( apply_filters( 'bp_core_template_plugin', 'members/single/plugins' ) );
+    }
+
+
+    // Helper function used by display_tegoed() for showing the total of studie bedrag or studie dagen
+    function calculateTotal($type) {
+        $user_id = get_current_user_id();
+        $the_query = new WP_Query(array(
+            'post_type'         => 'tegoeden',
+            'orderby'           => 'publish_date',
+            'order'             => 'ASC',
+            'posts_per_page'    => -1,
+            'meta_query'        => array(
+                array(
+                    array( 'key' => 'type', 'value' => $type, 'compare' => '=' ),
+                    array( 'key' => 'medewerker', 'value' => $user_id, 'compare' => '=' ),
+                    'relation' => 'AND'
+                )
+            )
+        ));
+        if ( $the_query->have_posts() ) {
+            $sum = 0;
+            while ($the_query->have_posts()) : $the_query->the_post();
+            $sum += get_post_meta( get_the_ID(), 'aanpassing', 'single' );
+            endwhile;
+        }
+        wp_reset_postdata();
+        return $sum;
+    }
+
+    // Function for displaying the various rows of tegoed (dagen en bedrag) a medewerker has
+    function display_tegoed($type) {
+        $user_id = get_current_user_id();
+        $the_query = new WP_Query(array(
+            'post_type'         => 'tegoeden',
+            'orderby'           => 'publish_date',
+            'order'             => 'DESC',
+            'posts_per_page'    => -1,
+            'meta_query'        => array(
+                array(
+                array( 'key' => 'type', 'value' => $type, 'compare' => '=' ),
+                array( 'key' => 'medewerker', 'value' => $user_id, 'compare' => '=' ),
+                'relation' => 'AND'
+                )
+            )
+        ));
+
+        echo '<div class="tegoed__row">' .
+            '<div class="tegoed__title"><strong>Totaal</strong></div>' .
+            '<div class="tegoed__aanpassing"><strong>' . calculateTotal($type) . '</strong></div>' .
+        '</div>';
+
+        if ( $the_query->have_posts() ) {
+            echo '<div class="tegoed__wrapper">';
+            while ($the_query->have_posts()) : $the_query->the_post();
+                get_template_part('tegoed-overview');
+            endwhile;
+            echo '</div>';
+        }
+        wp_reset_postdata();
+    }
+
+
+    /* 
+     *  Register custom post type tegoeden.
+     */
+
+    function cptui_register_my_cpts_tegoeden() {    
+        $labels = [
+            "name" => __( "Tegoeden", "woffice" ),
+            "singular_name" => __( "Tegoed", "woffice" ),
+            "menu_name" => __( "Tegoeden", "woffice" ),
+            "all_items" => __( "Alle Tegoeden", "woffice" ),
+            "add_new" => __( "Add tegoed", "woffice" ),
+            "add_new_item" => __( "Add new Tegoed", "woffice" ),
+            "edit_item" => __( "Update Tegoed", "woffice" ),
+            "new_item" => __( "New Tegoed", "woffice" ),
+            "view_item" => __( "View Tegoed", "woffice" ),
+            "view_items" => __( "View Tegoeden", "woffice" ),
+            "search_items" => __( "Search Tegoeden", "woffice" ),
+            "not_found" => __( "No Tegoeden found", "woffice" ),
+            "not_found_in_trash" => __( "No Tegoeden found in trash", "woffice" ),
+            "parent" => __( "Parent Tegoed:", "woffice" ),
+            "featured_image" => __( "Featured image for this Tegoed", "woffice" ),
+            "set_featured_image" => __( "Set featured image for this Tegoed", "woffice" ),
+            "remove_featured_image" => __( "Remove featured image for this Tegoed", "woffice" ),
+            "use_featured_image" => __( "Use as featured image for this Tegoed", "woffice" ),
+            "archives" => __( "Tegoed archives", "woffice" ),
+            "insert_into_item" => __( "Insert into Tegoed", "woffice" ),
+            "uploaded_to_this_item" => __( "Upload to this Tegoed", "woffice" ),
+            "filter_items_list" => __( "Filter Tegoeden list", "woffice" ),
+            "items_list_navigation" => __( "Tegoeden list navigation", "woffice" ),
+            "items_list" => __( "Tegoeden list", "woffice" ),
+            "attributes" => __( "Tegoeden attributes", "woffice" ),
+            "name_admin_bar" => __( "Tegoed", "woffice" ),
+            "item_published" => __( "Tegoed published", "woffice" ),
+            "item_published_privately" => __( "Tegoed published privately.", "woffice" ),
+            "item_reverted_to_draft" => __( "Tegoed reverted to draft.", "woffice" ),
+            "item_scheduled" => __( "Tegoed scheduled", "woffice" ),
+            "item_updated" => __( "Tegoed updated.", "woffice" ),
+            "parent_item_colon" => __( "Parent Tegoed:", "woffice" ),
+        ];
+    
+        $args = [
+            "label" => __( "Tegoeden", "woffice" ),
+            "labels" => $labels,
+            "description" => "",
+            "public" => true,
+            "publicly_queryable" => false,
+            "show_ui" => true,
+            "delete_with_user" => false,
+            "show_in_rest" => true,
+            "rest_base" => "",
+            "rest_controller_class" => "WP_REST_Posts_Controller",
+            "has_archive" => false,
+            "show_in_menu" => true,
+            "show_in_nav_menus" => false,
+            "delete_with_user" => false,
+            "exclude_from_search" => false,
+            "capability_type" => "post",
+            "map_meta_cap" => true,
+            "hierarchical" => false,
+            "rewrite" => [ "slug" => "tegoeden", "with_front" => true ],
+            "query_var" => true,
+            "supports" => [ "title", "custom-fields" ],
+        ];
+    
+        register_post_type( "tegoeden", $args );
+    }
+    add_action( 'init', 'cptui_register_my_cpts_tegoeden' );
+    
+    // Adjust title field for custom post type tegoeden.
+    function tegoeden_title_placeholder($title , $post){
+        
+        if( $post->post_type == 'tegoeden' ){
+            $tegoed_title = "Omschrijving van de aanpassing";
+            return $tegoed_title;
+        }
+        return $title;
+    }
+    add_filter('enter_title_here', 'tegoeden_title_placeholder' , 20 , 2 );
+
+    // Admin sectie in backend, add meta data columns
+    function filter_tegoed_posts_columns( $columns ) {
+        $columns = array(
+            'cb' => $columns['cb'],
+            'date' => __( 'Datum' ),
+            'medewerker' => __( 'Medewerker' ),
+            'type' => __( 'Type' ),
+            'title' => __( 'Omschrijving aanpassing' ),
+            'aanpassing' => __( 'Aanpassing' ),
+        );
+        return $columns;
+    }
+    add_filter( 'manage_tegoeden_posts_columns', 'filter_tegoed_posts_columns' );
+
+    // Admin sectie in backend, add meta data column data
+    function populate_tegoed_column( $column, $post_id ) {
+        if ( 'medewerker' === $column ) {
+            $user_id = get_post_meta( $post_id, 'medewerker', true );
+            $user = get_userdata($user_id);
+            echo $user->display_name;
+        }
+        if ( 'type' === $column ) {
+            echo get_post_meta( $post_id, 'type', true );
+        }
+        if ( 'aanpassing' === $column ) {
+            echo get_post_meta( $post_id, 'aanpassing', true );
+        }
+    }
+    add_action( 'manage_tegoeden_posts_custom_column', 'populate_tegoed_column', 10, 2);
+
+
+    // Function for populating the medewerkers custom field
+    function acf_load_medewerker_choices( $field ) {
+        $field['choices'] = array();
+
+        $employees = get_users();
+        foreach ($employees as $user) {
+            $add_tegoed = get_post_meta( $user->ID, 'enable_tegoeden', 'single' );
+            $field['choices'][$user->ID] = $user->display_name . ' - ' . $add_tegoed;
+        }
+        return $field;
+    }
+    add_filter('acf/load_field/name=medewerker', 'acf_load_medewerker_choices');
+    
+?>
+

--- a/functions.php
+++ b/functions.php
@@ -49,8 +49,9 @@
                 )
             )
         ));
+
+        $sum = 0;
         if ( $the_query->have_posts() ) {
-            $sum = 0;
             while ($the_query->have_posts()) : $the_query->the_post();
             $sum += get_post_meta( get_the_ID(), 'aanpassing', 'single' );
             endwhile;
@@ -270,19 +271,19 @@
      *  For debugging, the Crontrol WP plugin can be helpful to see the scheduled cron jobs
      */
 
-    // When no cron is available yet, add an hourly cron to fire the tegoeden_hourly_crop_job action.
+    // When no cron is set yet, add an hourly cron to fire the tegoeden_hourly_cron_job action.
     function activate_tegoeden_cron() {
-        if (!wp_next_scheduled('tegoeden_hourly_crop_job')) {
+        if (!wp_next_scheduled('tegoeden_hourly_cron_job')) {
             $at_six_am = strtotime('06:00:00');
-            wp_schedule_event($at_six_am, 'daily', 'tegoeden_hourly_crop_job');
+            wp_schedule_event($at_six_am, 'daily', 'tegoeden_hourly_cron_job');
         }    
     }
 
     // Call the actual function to activate the cron. It'll only run once.
     activate_tegoeden_cron();
 
-    // Linking the tegoeden_hourly_crop_job to the check_dates_add_tegoeden function
-    add_action( 'tegoeden_hourly_crop_job',  'check_dates_add_tegoeden' );
+    // Linking the tegoeden_hourly_cron_job to the check_dates_add_tegoeden function
+    add_action( 'tegoeden_hourly_cron_job',  'check_dates_add_tegoeden' );
 
     // Check if the it's the 1st of the month and fire the monthly or half yearly functions.
     function check_dates_add_tegoeden() {
@@ -300,7 +301,7 @@
     }
     add_action('check_dates_add_tegoeden_cron', 'check_dates_add_tegoeden');
 
-
+    // Add for each developer 1 studie dag
     function monthly_dagen_update() {
         $developerIds = getDeveloperIds();
         foreach($developerIds as $id) {
@@ -318,6 +319,7 @@
         }
     }
 
+    // Add for each developer 250 studie tegoed
     function half_yearly_bedrag_update() {
         $developerIds = getDeveloperIds();
         foreach($developerIds as $id) {

--- a/functions.php
+++ b/functions.php
@@ -204,6 +204,16 @@
             "rewrite" => [ "slug" => "tegoeden", "with_front" => true ],
             "query_var" => true,
             "supports" => [ "title", "custom-fields" ],
+            'capabilities' => array(
+                'edit_post'          => 'update_core',
+                'read_post'          => 'update_core',
+                'delete_post'        => 'update_core',
+                'edit_posts'         => 'update_core',
+                'edit_others_posts'  => 'update_core',
+                'delete_posts'       => 'update_core',
+                'publish_posts'      => 'update_core',
+                'read_private_posts' => 'update_core'
+            ),
         ];
     
         register_post_type( "tegoeden", $args );
@@ -289,7 +299,7 @@
     function check_dates_add_tegoeden() {
         $month = date('m');
         $day = date('d');
-        if ('01' === $day || true) {
+        if ('01' === $day) {
             // run the monthly studie dagen function every 1st day of the month
             monthly_dagen_update();
 

--- a/style.css
+++ b/style.css
@@ -544,3 +544,51 @@ td {
 }
 
 /* #endregion */
+
+.tegoed__wrapper {
+  border-top: 3px solid #ffa400;
+}
+
+.tegoed__row {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: stretch;
+}
+
+.tegoed__row div {
+  border-bottom: 1px solid #ccc;
+  padding: 0.5rem;
+}
+
+.tegoed__date {
+  min-width: 150px;
+}
+
+.tegoed__title {
+  flex-grow: 1;
+}
+
+.tegoed__aanpassing {
+  min-width: 50px;
+  text-align: right;
+}
+
+.tegoed__negatief {
+  color: red;
+}
+
+#content-container
+  div#object-nav.item-list-tabs
+  ul
+  li#fa-calendar-personal-li
+  > a::before {
+  content: "\f133";
+}
+
+#content-container
+  div#object-nav.item-list-tabs
+  ul
+  li#fa-money-personal-li
+  > a::before {
+  content: "\f0d6";
+}

--- a/tegoed-overview.php
+++ b/tegoed-overview.php
@@ -1,0 +1,7 @@
+<?php $value = get_post_meta( get_the_ID(), 'aanpassing', 'single' ); ?>
+
+<div class="tegoed__row">
+    <div class="tegoed__date"><?php echo get_the_date(); ?></div>
+    <div class="tegoed__title"><?php the_title(); ?></div>
+    <div class="tegoed__aanpassing<?php echo ($value < 0 ? ' tegoed__negatief' : ''); ?>"><?php echo $value; ?></div>
+</div>

--- a/wp-cron.php
+++ b/wp-cron.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * A pseudo-CRON daemon for scheduling WordPress tasks
+ *
+ * WP Cron is triggered when the site receives a visit. In the scenario
+ * where a site may not receive enough visits to execute scheduled tasks
+ * in a timely manner, this file can be called directly or via a server
+ * CRON daemon for X number of times.
+ *
+ * Defining DISABLE_WP_CRON as true and calling this file directly are
+ * mutually exclusive and the latter does not rely on the former to work.
+ *
+ * The HTTP request to this file will not slow down the visitor who happens to
+ * visit when the cron job is needed to run.
+ *
+ * @package WordPress
+ */
+
+ignore_user_abort( true );
+
+/* Don't make the request block till we finish, if possible. */
+if ( function_exists( 'fastcgi_finish_request' ) && version_compare( phpversion(), '7.0.16', '>=' ) ) {
+	if ( ! headers_sent() ) {
+		header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
+		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
+	}
+
+	fastcgi_finish_request();
+}
+
+if ( ! empty( $_POST ) || defined( 'DOING_AJAX' ) || defined( 'DOING_CRON' ) ) {
+	die();
+}
+
+/**
+ * Tell WordPress we are doing the CRON task.
+ *
+ * @var bool
+ */
+define( 'DOING_CRON', true );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	/** Set up WordPress environment */
+	require_once( dirname( __FILE__ ) . '/wp-load.php' );
+}
+
+/**
+ * Retrieves the cron lock.
+ *
+ * Returns the uncached `doing_cron` transient.
+ *
+ * @ignore
+ * @since 3.3.0
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @return string|false Value of the `doing_cron` transient, 0|false otherwise.
+ */
+function _get_cron_lock() {
+	global $wpdb;
+
+	$value = 0;
+	if ( wp_using_ext_object_cache() ) {
+		/*
+		 * Skip local cache and force re-fetch of doing_cron transient
+		 * in case another process updated the cache.
+		 */
+		$value = wp_cache_get( 'doing_cron', 'transient', true );
+	} else {
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", '_transient_doing_cron' ) );
+		if ( is_object( $row ) ) {
+			$value = $row->option_value;
+		}
+	}
+
+	return $value;
+}
+
+$crons = wp_get_ready_cron_jobs();
+if ( empty( $crons ) ) {
+	die();
+}
+
+$gmt_time = microtime( true );
+
+// The cron lock: a unix timestamp from when the cron was spawned.
+$doing_cron_transient = get_transient( 'doing_cron' );
+
+// Use global $doing_wp_cron lock otherwise use the GET lock. If no lock, trying grabbing a new lock.
+if ( empty( $doing_wp_cron ) ) {
+	if ( empty( $_GET['doing_wp_cron'] ) ) {
+		// Called from external script/job. Try setting a lock.
+		if ( $doing_cron_transient && ( $doing_cron_transient + WP_CRON_LOCK_TIMEOUT > $gmt_time ) ) {
+			return;
+		}
+		$doing_wp_cron        = sprintf( '%.22F', microtime( true ) );
+		$doing_cron_transient = $doing_wp_cron;
+		set_transient( 'doing_cron', $doing_wp_cron );
+	} else {
+		$doing_wp_cron = $_GET['doing_wp_cron'];
+	}
+}
+
+/*
+ * The cron lock (a unix timestamp set when the cron was spawned),
+ * must match $doing_wp_cron (the "key").
+ */
+if ( $doing_cron_transient != $doing_wp_cron ) {
+	return;
+}
+
+foreach ( $crons as $timestamp => $cronhooks ) {
+	if ( $timestamp > $gmt_time ) {
+		break;
+	}
+
+	foreach ( $cronhooks as $hook => $keys ) {
+
+		foreach ( $keys as $k => $v ) {
+
+			$schedule = $v['schedule'];
+
+			if ( $schedule ) {
+				wp_reschedule_event( $timestamp, $schedule, $hook, $v['args'] );
+			}
+
+			wp_unschedule_event( $timestamp, $hook, $v['args'] );
+
+			/**
+			 * Fires scheduled events.
+			 *
+			 * @ignore
+			 * @since 2.1.0
+			 *
+			 * @param string $hook Name of the hook that was scheduled to be fired.
+			 * @param array  $args The arguments to be passed to the hook.
+			 */
+			do_action_ref_array( $hook, $v['args'] );
+
+			// If the hook ran too long and another cron process stole the lock, quit.
+			if ( _get_cron_lock() != $doing_wp_cron ) {
+				return;
+			}
+		}
+	}
+}
+
+if ( _get_cron_lock() == $doing_wp_cron ) {
+	delete_transient( 'doing_cron' );
+}
+
+die();


### PR DESCRIPTION
In de PR zijn de volgende commits opgenomen:
- Add only allow admin role to view tegoeden
- Add Total tegoed: 0 if not present and add/update comments
- Add cron job logic
- Add tegoed total in buttons
- Enable tegoeden only for users who have them activate
- Add both tabs and tab content and style them.

**NOTE:**
Omdat WordPress cron jobs niet betrouwbaar zijn, bijv als niemand op een dag de website bezoekt, dan wordt de job niet getriggered, vandaar dat er op de web server een CRON job aangemaakt wordt, die dagelijks `wp-cron.php` aanroept.
In deze repo staat dit bestand in de child-theme directory maar dient in de hoofd directory van WordPress te staan. Er zal dus een copie van het bestand in de theme directory naar de root gemaakt moeten worden. 

Als tijdelijke oplossing wordt de CRON getriggerd door een web cron op https://cron-job.org/en/members/jobs/ 